### PR TITLE
chore: remove last indirect dependency to gliderlabs/ssh

### DIFF
--- a/_examples/ssh-sftpserver/sftp.go
+++ b/_examples/ssh-sftpserver/sftp.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/gliderlabs/ssh"
+	"github.com/tailscale/gliderssh"
 	"github.com/pkg/sftp"
 )
 


### PR DESCRIPTION
Pulling github.com/tailscale/gliderssh should not add github.com/gliderlabs/ssh as indirect dependency