### PR TITLE
Remove go-shlex and update golang.org/x/crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/tailscale/gliderssh
 
 go 1.26
 
-require golang.org/x/crypto v0.31.0
+require golang.org/x/crypto v0.52.0
 
-require golang.org/x/sys v0.28.0 // indirect
+require golang.org/x/sys v0.45.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/tailscale/gliderssh
 
 go 1.26
 
-require (
-	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
-	golang.org/x/crypto v0.31.0
-)
+require golang.org/x/crypto v0.31.0
 
 require golang.org/x/sys v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
-golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
-github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=

--- a/session.go
+++ b/session.go
@@ -7,7 +7,8 @@ import (
 	"net"
 	"sync"
 
-	"github.com/anmitsu/go-shlex"
+	"github.com/tailscale/gliderssh/shlex"
+
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -217,7 +218,7 @@ func (sess *session) RawCommand() string {
 }
 
 func (sess *session) Command() []string {
-	cmd, _ := shlex.Split(sess.rawCmd, true)
+	cmd, _ := shlex.SplitPosix(sess.rawCmd)
 	return append([]string(nil), cmd...)
 }
 

--- a/shlex/shlex.go
+++ b/shlex/shlex.go
@@ -1,0 +1,198 @@
+// Splitting command-line strings into words like a Posix shell would do
+// Code from https://github.com/buildkite/shellwords/tree/v1.0.1 (MIT)
+// but only with SplitPosix support
+
+package shlex
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// This is a recursive descent parser for our basic shellword grammar.
+
+const (
+	eof               = -1
+	posixSpecialChars = "!\"#$&'()*,;<=>?[]\\^`{}|~"
+	posixEscape       = '\\'
+)
+
+// Parser takes a string and parses out a tree of structs that represent text and Expansions
+type parser struct {
+	// Input is the string to parse
+	Input string
+
+	// Characters to use for quoted strings
+	QuoteChars []rune
+
+	// The character used for escaping
+	EscapeChar rune
+
+	// The characters used for escaping quotes in quoted strings
+	QuoteEscapeChars []rune
+
+	// Field seperators are used for splitting words
+	FieldSeperators []rune
+
+	// The current internal position
+	pos int
+}
+
+func (p *parser) parse() ([]string, error) {
+	var word strings.Builder
+
+	words := []string{}
+	token := false // Used to force token emission, even if empty
+
+	for {
+		// Read until we encounter a delimiter character
+		scanned := p.scanUntil(func(r rune) bool {
+			return r == p.EscapeChar || p.isQuote(r) || p.isFieldSeperator(r)
+		})
+
+		if len(scanned) > 0 {
+			word.WriteString(scanned)
+		}
+
+		// Read the character that caused the scan to stop
+		r := p.nextRune()
+		if r == eof {
+			break
+		}
+
+		switch {
+		// Handle quotes
+		case p.isQuote(r):
+			quote, err := p.scanQuote(r)
+			if err != nil {
+				return nil, err
+			}
+
+			token = true // Ensure a token will be emitted, even if empty (e.g. "")
+
+			// Write to the buffer
+			word.WriteString(quote)
+
+		// Handle escaped characters
+		case r == p.EscapeChar:
+			if escaped := p.nextRune(); escaped != eof {
+				word.WriteRune(escaped)
+			}
+			continue
+
+		// Handle field seperators
+		case p.isFieldSeperator(r):
+			if word.Len() > 0 || token {
+				words = append(words, word.String())
+				word.Reset()
+				token = false
+			}
+
+		default:
+			return nil, fmt.Errorf("unhandled character %c at pos %d", r, p.pos)
+		}
+	}
+
+	if word.Len() > 0 || token {
+		words = append(words, word.String())
+		word.Reset()
+	}
+
+	return words, nil
+}
+
+func (p *parser) scanQuote(delim rune) (string, error) {
+	var quote strings.Builder
+
+	for {
+		r := p.nextRune()
+		if r == eof {
+			return "", fmt.Errorf("expected closing quote %c at offset %d, got EOF", delim, p.pos-1)
+		}
+		// Check for escaped characters
+		if escapeChar, escaped := p.isQuoteEscape(r); escaped {
+			// Handle the case where our escape char is our delimiter (e.g "")
+			if escapeChar != delim || p.peekRune() == delim {
+				if escaped := p.nextRune(); escaped != eof {
+					quote.WriteRune(escaped)
+				}
+				continue
+			}
+		}
+		if r == delim {
+			break
+		}
+		quote.WriteRune(r)
+	}
+
+	return quote.String(), nil
+}
+
+func (p *parser) isQuote(r rune) bool {
+	for _, qr := range p.QuoteChars {
+		if qr == r {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) isQuoteEscape(r rune) (rune, bool) {
+	for _, qr := range p.QuoteEscapeChars {
+		if qr == r {
+			return qr, true
+		}
+	}
+	return r, false
+}
+
+func (p *parser) isFieldSeperator(r rune) bool {
+	for _, qr := range p.FieldSeperators {
+		if qr == r {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) scanUntil(f func(rune) bool) string {
+	start := p.pos
+	for p.pos < len(p.Input) {
+		c, size := utf8.DecodeRuneInString(p.Input[p.pos:])
+		if c == utf8.RuneError || f(c) {
+			break
+		}
+		p.pos += size
+	}
+	return p.Input[start:p.pos]
+}
+
+func (p *parser) nextRune() rune {
+	if p.pos >= len(p.Input) {
+		return eof
+	}
+	c, size := utf8.DecodeRuneInString(p.Input[p.pos:])
+	p.pos += size
+	return c
+}
+
+func (p *parser) peekRune() rune {
+	if p.pos >= len(p.Input) {
+		return eof
+	}
+	c, _ := utf8.DecodeRuneInString(p.Input[p.pos:])
+	return c
+}
+
+// SplitPosix splits a command string into words like a posix shell would
+func SplitPosix(line string) ([]string, error) {
+	p := parser{
+		Input:            line,
+		QuoteChars:       []rune{'\'', '"'},
+		EscapeChar:       posixEscape,
+		QuoteEscapeChars: []rune{posixEscape},
+		FieldSeperators:  []rune{'\n', '\t', ' '},
+	}
+	return p.parse()
+}

--- a/shlex/shlex_test.go
+++ b/shlex/shlex_test.go
@@ -1,0 +1,75 @@
+package shlex_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tailscale/gliderssh/shlex"
+)
+
+func TestSplitPosix(t *testing.T) {
+	testCases := []struct {
+		String   string
+		Expected []string
+	}{
+		{
+			"true", []string{
+				"true",
+			},
+		},
+		{
+			`simple --string "quoted"`, []string{
+				"simple",
+				"--string",
+				"quoted",
+			},
+		},
+		{
+			`\\\""quoted" llamas 'test\''`, []string{
+				`\"quoted`,
+				"llamas",
+				"test'",
+			},
+		},
+		{
+			`/usr/bin/bash -e -c "llamas are the \"best\" && echo 'alpacas'"`, []string{
+				"/usr/bin/bash",
+				"-e",
+				"-c",
+				`llamas are the "best" && echo 'alpacas'`,
+			},
+		},
+		{
+			`"/bin"/ba'sh' -c echo\ \\\\"fo real"`, []string{
+				"/bin/bash",
+				"-c",
+				`echo \\fo real`,
+			},
+		},
+		{
+			`echo 'abc'\''abc'`, []string{
+				"echo",
+				"abc'abc",
+			},
+		},
+		{
+			`echo "abc"\""abc"`, []string{
+				"echo",
+				`abc"abc`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			actual, err := shlex.SplitPosix(tc.String)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Fatalf("Expected vs Actual: \n%#v\n\n%#v", tc.Expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This MR replaces the split on words feature with vendored code taken from a better designed lib : https://github.com/buildkite/shellwords.

This is a very small feature which can easily be vendored to reduce the dependency tree and improve security by reducing another vector of supply-chain attack.

This MR also updates the crypto lib to the latest version

(I was looking for a better maintained fork to of gliderssh and I stumbled upon yours)